### PR TITLE
Fix rebootVPC by UUID

### DIFF
--- a/rebootVPC.py
+++ b/rebootVPC.py
@@ -108,7 +108,8 @@ else:
     projectParam = "false"
 
 # check routerID
-VPCUUID = c.checkCloudStackName({'csname': vpcname,
+if len(vpcuuid) == 0:
+    vpcuuid = c.checkCloudStackName({'csname': vpcname,
                                   'csApiCall': 'listVPCs',
                                   'listAll': 'true',
                                   'isProjectVm': projectParam})
@@ -116,16 +117,13 @@ VPCUUID = c.checkCloudStackName({'csname': vpcname,
 if len(networkuuid) > 0:
     print "Note: Getting VPC id from network uuid %s" % networkuuid
     network = c.listNetworks(networkuuid)[0]
-    VPCUUID = network.vpcid
+    vpcuuid = network.vpcid
 
-if not VPCUUID:
-    VPCUUID = vpcuuid
-
-if VPCUUID == 1 or VPCUUID == "":
+if vpcuuid == 1 or vpcuuid == "":
     print "Error: VPC cannot be found!"
     exit(1)
 
-vpc = c.listVPCs(VPCUUID)[0]
+vpc = c.listVPCs(vpcuuid)[0]
 
 print "Note: Found VPC " + vpcname
 
@@ -138,25 +136,25 @@ c.zone_name = vpc.zonename
 print "Note: Let's reboot the VPC.."
 
 if DRYRUN == 1:
-    print "Note: Would have rebooted vpc " + vpc.name + " (" + VPCUUID + ")"
+    print "Note: Would have rebooted vpc " + vpc.name + " (" + vpcuuid + ")"
 else:
     # If the network is a VPC
     c.task = "Restart VPC with clean up"
-    message = "Restarting VPC " + vpc.name + " with clean up (" + VPCUUID + ")"
+    message = "Restarting VPC " + vpc.name + " with clean up (" + vpcuuid + ")"
     c.print_message(message=message, message_type="Note", to_slack=True)
-    result = c.restartVPC(VPCUUID)
+    result = c.restartVPC(vpcuuid)
     if result == 1:
         print "Restarting failed, will try again!"
-        result = c.restartVPC(VPCUUID)
+        result = c.restartVPC(vpcuuid)
         if result == 1:
-            message = "Restarting VPC " + vpc.name + "(" + VPCUUID + ") with clean up failed.\nError: investigate manually!"
+            message = "Restarting VPC " + vpc.name + "(" + vpcuuid + ") with clean up failed.\nError: investigate manually!"
             c.print_message(message=message, message_type="Error", to_slack=True)
             sys.exit(1)
         else:
-            message = "Successfully restarted VPC " + vpc.name + " (" + VPCUUID + ")"
+            message = "Successfully restarted VPC " + vpc.name + " (" + vpcuuid + ")"
             c.print_message(message=message, message_type="Note", to_slack=True)
     else:
-        message = "Successfully restarted VPC " + vpc.name + " (" + VPCUUID + ")"
+        message = "Successfully restarted VPC " + vpc.name + " (" + vpcuuid + ")"
         c.print_message(message=message, message_type="Note", to_slack=True)
 
 


### PR DESCRIPTION
```
> ./rebootVPC.py -c beta-nl1 --uuid 97f55b82-5e94-46ba-9f28-a62edd87865a
Welcome to CloudStackOps
Warning: dry-run mode is enabled, not running any commands!
Note: Trying to use API credentials from CloudMonkey profile 'beta-nl1'
Note: Connected to 'http://172.16.1.143:8080/client/api'
Note: Found VPC
Note: Let's reboot the VPC..
Note: Would have rebooted vpc Ian Testing 2 (97f55b82-5e94-46ba-9f28-a62edd87865a)
Note: We're done!
rbergsma@mccmadm1 [ ~/git/cloudstackOps ] (14:37:00 - Tue Jan 08)
> ./rebootVPC.py -c beta-nl1 -v kvmtest1
Welcome to CloudStackOps
Warning: dry-run mode is enabled, not running any commands!
Note: Trying to use API credentials from CloudMonkey profile 'beta-nl1'
Note: Connected to 'http://172.16.1.143:8080/client/api'
Note: Found VPC kvmtest1
Note: Let's reboot the VPC..
Note: Would have rebooted vpc kvmtest1 (665d7ea8-cf9e-11e7-b605-5254004d8d30)
Note: We're done!
```